### PR TITLE
updated readme for use with strapi 4.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ module.exports = [
         useDefaults: true,
         directives: {
           'connect-src': ["'self'", 'https:'],
-          'img-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_PULL_ZONE"), env("BUNNYCDN_PULL_ZONE")],
-          'media-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_PULL_ZONE"), env("BUNNYCDN_PULL_ZONE")],
+          'img-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_STORAGE_ZONE"), env("BUNNYCDN_PULL_ZONE")],
+          'media-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_STORAGE_ZONE"), env("BUNNYCDN_PULL_ZONE")],
           upgradeInsecureRequests: null,
         },
       },

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ module.exports = [
         useDefaults: true,
         directives: {
           'connect-src': ["'self'", 'https:'],
-          'img-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_STORAGE_ZONE"), env("BUNNYCDN_PULL_ZONE")],
-          'media-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_STORAGE_ZONE"), env("BUNNYCDN_PULL_ZONE")],
+          'img-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_HOST"), env("BUNNYCDN_PULL_ZONE")],
+          'media-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_HOST"), env("BUNNYCDN_PULL_ZONE")],
           upgradeInsecureRequests: null,
         },
       },

--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ See the [using a provider](https://strapi.io/documentation/developer-docs/latest
 module.exports = ({ env }) => ({
   //...
   upload: {
-    provider: 'bunnycdn',
-    providerOptions: {
-      region: env('BUNNYCDN_HOST'),
-      apiKey: env('BUNNYCDN_API_KEY'),
-      storageZone: env('BUNNYCDN_STORAGE_ZONE'),
-      pullZone: env('BUNNYCDN_PULL_ZONE')
+    config: {
+      provider: "strapi-provider-upload-bunnycdn",
+      providerOptions: {
+        region: env("BUNNYCDN_HOST"),
+        apiKey: env("BUNNYCDN_API_KEY"),
+        storageZone: env("BUNNYCDN_STORAGE_ZONE"),
+        pullZone: env("BUNNYCDN_PULL_ZONE"),
+      },
+    },
+    actionOptions: {
+      upload: {},
+      delete: {},
     },
   },
   //...
@@ -33,4 +39,31 @@ BUNNYCDN_HOST: Storage primary Hostname (Inside FTP & API Access).
 BUNNYCDN_API_KEY: Storage Password (Inside FTP & API Access).
 BUNNYCDN_STORAGE_ZONE: Storage Zone name.
 BUNNYCDN_PULL_ZONE: Pull Zone name.
+```
+
+### Security Middleware Configuration
+
+Due to the default settings in the Strapi Security Middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library. You should replace `strapi::security` string with the object bellow instead as explained in the [middleware configuration](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.html#loading-order) documentation.
+
+`./config/middlewares.js`
+
+```js
+module.exports = [
+  // ...
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_PULL_ZONE"), env("BUNNYCDN_PULL_ZONE")],
+          'media-src': ["'self'", 'data:', 'blob:', 'dl.airtable.com', env("BUNNYCDN_PULL_ZONE"), env("BUNNYCDN_PULL_ZONE")],
+          upgradeInsecureRequests: null,
+        },
+      },
+    },
+  },
+  // ...
+];
 ```


### PR DESCRIPTION
Hey, So after playing with this for a little bit I have been able to confirm this provider is still functioning with strapi 4.2.3 with a tweak to the documented config. I thought it worth making this pull request in case others find themselves in the same position. 

It's also worth noting that you receive a below warning as support for the new uploadStream is not implemented. I haven't time to include a fix for this at the moment, and in development, the performance seems ok. I will raise another Pull Request when I have time to resolve

Warning: The upload provider "strapi-provider-upload-bunnycdn" doesn't implement the uploadStream function. Strapi will fallback on the upload method. Some performance issues may occur.
